### PR TITLE
Add Node.js 24.x to CI workflow

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -13,7 +13,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [20.x, 22.x, 23.x]
+                node-version: [20.x, 22.x, 23.x, 24.x]
 
         steps:
             - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
@@ -23,12 +23,9 @@ jobs:
               uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
               with:
                   node-version: ${{ matrix.node-version }}
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v4.0.0
             - name: Install and test
               run: |
-                  pnpm install
-                  make test
+                  npm install-ci-test
               env:
                   CODECOV_UPLOAD_BUNDLE_TOKEN: ${{ secrets.CODECOV_UPLOAD_BUNDLE_TOKEN }}
             - name: Codecov install cli


### PR DESCRIPTION
This pull request updates the Node.js workflow configuration to add support for Node.js 24.x and simplifies the install and test steps by switching from `pnpm` to `npm`. The most important changes are:

**Node.js version support:**

* Added Node.js 24.x to the matrix of tested versions in `.github/workflows/node.yml`, ensuring our code is compatible with the latest Node.js release.

**Build and test process simplification:**

* Removed the setup for `pnpm` and replaced the install and test commands with a single `npm install-ci-test` command, streamlining the workflow and reducing dependencies.