### PR TITLE
Centralize message ID constants for protocol discoverability

### DIFF
--- a/packages/authentication/src/handlers/registry.ts
+++ b/packages/authentication/src/handlers/registry.ts
@@ -21,7 +21,7 @@
  * Includes both login handlers (port 8226) and persona handlers (port 8228).
  */
 
-import { MessageHandlerRegistry } from 'rusty-motors-shared';
+import { MessageHandlerRegistry, AUTH_MESSAGE_IDS } from 'rusty-motors-shared';
 import type { ServerLogger, LegacyMessage } from 'rusty-motors-shared';
 import type { GamePacket } from 'rusty-motors-protocol';
 import type { BytableMessage, BytableBuffer } from '@rustymotors/binary';
@@ -67,44 +67,44 @@ export function createAuthHandlerRegistry(): MessageHandlerRegistry<
 
     // Login handlers (port 8226)
     registry.register({
-        opCode: 0x501, // 1281
+        opCode: AUTH_MESSAGE_IDS.USER_LOGIN,
         name: 'UserLogin',
         handler: login,
     });
 
     // Persona handlers (port 8228)
     registry.register({
-        opCode: 0x503, // 1283
+        opCode: AUTH_MESSAGE_IDS.GAME_LOGIN,
         name: 'Game login',
         handler: _selectGamePersona,
     });
 
     registry.register({
-        opCode: 0x50F, // 1295
+        opCode: AUTH_MESSAGE_IDS.GAME_LOGOUT,
         name: 'Game logout',
         handler: _gameLogout,
     });
 
     registry.register({
-        opCode: 0x519, // 1305
+        opCode: AUTH_MESSAGE_IDS.GET_PERSONA_INFO,
         name: 'Get persona info',
         handler: getPersonaInfo,
     });
 
     registry.register({
-        opCode: 0x532, // 1330
+        opCode: AUTH_MESSAGE_IDS.GET_PERSONA_MAPS,
         name: 'Get persona maps',
         handler: getPersonaMaps,
     });
 
     registry.register({
-        opCode: 0x533, // 1331
+        opCode: AUTH_MESSAGE_IDS.VALIDATE_PERSONA_NAME,
         name: 'Validate persona name',
         handler: validatePersonaName,
     });
 
     registry.register({
-        opCode: 0x50B, // 1291
+        opCode: AUTH_MESSAGE_IDS.GET_FIRST_BUDDY,
         name: 'Get first buddy',
         handler: _getFirstBuddy,
     });

--- a/packages/lobby/src/handlers/handleOpenCommChannel.ts
+++ b/packages/lobby/src/handlers/handleOpenCommChannel.ts
@@ -1,6 +1,7 @@
 import { BytableMessage } from '@rustymotors/binary';
 import {
     getServerLogger,
+    NPS_MESSAGE_IDS,
     RawMessage,
     type Serializable,
     type ServerLogger,
@@ -85,7 +86,7 @@ export async function handleOpenCommChannel({
             );
 
             const userJoinedMessage = BytableMessage.FromRawMessage(
-                createRawMessage(0x20c, userJoined),
+                createRawMessage(NPS_MESSAGE_IDS.USER_JOINED_CHANNEL, userJoined),
             );
 
             log.debug('Outbound user join message', {
@@ -128,7 +129,7 @@ export function createNPSChannelGrantedPacket(
         { name: 'port', field: 'Dword' },
     ]);
 
-    outgoingGameMessage.header.setId(0x214);
+    outgoingGameMessage.header.setId(NPS_MESSAGE_IDS.CHANNEL_GRANTED);
     outgoingGameMessage.setVersion(0);
     outgoingGameMessage.setFieldValueByName('commId', commId);
     outgoingGameMessage.setFieldValueByName('port', commPort);

--- a/packages/lobby/src/handlers/npsCommandHandlers.ts
+++ b/packages/lobby/src/handlers/npsCommandHandlers.ts
@@ -1,3 +1,4 @@
+import { NPS_MESSAGE_IDS } from "rusty-motors-shared";
 import { handleSendGameServersList } from "./_handleSendGameServersList.js";
 import { _setMyUserData } from "./_setMyUserData.js";
 import type { NpsCommandHandler } from "./encryptedCommand.js";
@@ -15,68 +16,68 @@ import { handleUdpStatus } from "./handlUdpStatus.js";
 
 export const npsCommandHandlers: NpsCommandHandler[] = [
 	{
-		opCode: 0x101,
+		opCode: NPS_MESSAGE_IDS.GET_USER_LIST,
 		name: "NPS_GET_USER_LIST",
-		handler: handleGetUserList
+		handler: handleGetUserList,
 	},
 	{
-		opCode: 0x105,
+		opCode: NPS_MESSAGE_IDS.CLOSE_COMM_CHANNEL,
 		name: "NPS_CLOSE_COMM_CHANNEL",
-		handler: handleCloseCommChannel
+		handler: handleCloseCommChannel,
 	},
 	{
-		opCode: 0x10a,
+		opCode: NPS_MESSAGE_IDS.START_GAME_SERVER,
 		name: "NPS_START_GAME_SERVER",
-		handler: handleStartGameServer
+		handler: handleStartGameServer,
 	},
 	{
-		opCode: 0x10c, // 268
+		opCode: NPS_MESSAGE_IDS.GET_SERVER_INFO,
 		name: "NPS_GET_SERVER_INFO",
 		handler: handleGetServerInfo,
 	},
-    {
-        opCode: 0x125,
-        name: "NPS_UDP_STATUS",
-        handler: handleUdpStatus
-    },
 	{
-		opCode: 0x128, // 296
+		opCode: NPS_MESSAGE_IDS.UDP_STATUS,
+		name: "NPS_UDP_STATUS",
+		handler: handleUdpStatus,
+	},
+	{
+		opCode: NPS_MESSAGE_IDS.GET_MINI_USER_LIST,
 		name: "NPS_GET_MINI_USER_LIST",
 		handler: handleGetMiniUserList,
 	},
 	{
-		opCode: 0x30c, // 780
+		opCode: NPS_MESSAGE_IDS.SEND_MINI_RIFF_LIST,
 		name: "NPS_SEND_MINI_RIFF_LIST",
 		handler: handleSendMiniRiffList,
 	},
-    {
-        opCode: 0x10d,
-        name: "NPS_SET_COMM_FLAGS",
-        handler: handleSetChannelFlags
-    },
-    {
-        opCode: 0x10e,
-        name: "NPS_GET_READY_LIST",
-        handler: handleGetReadyList
-    },
 	{
-		opCode: 0x103, // 259
+		opCode: NPS_MESSAGE_IDS.SET_COMM_FLAGS,
+		name: "NPS_SET_COMM_FLAGS",
+		handler: handleSetChannelFlags,
+	},
+	{
+		opCode: NPS_MESSAGE_IDS.GET_READY_LIST,
+		name: "NPS_GET_READY_LIST",
+		handler: handleGetReadyList,
+	},
+	{
+		opCode: NPS_MESSAGE_IDS.SET_MY_USER_DATA,
 		name: "NPS_SET_MY_USER_DATA",
 		handler: _setMyUserData,
 	},
 	{
-		opCode: 0x106,
+		opCode: NPS_MESSAGE_IDS.OPEN_COMM_CHANNEL,
 		name: "NPS_OPEN_COMM_CHANNEL",
-		handler: handleOpenCommChannel
+		handler: handleOpenCommChannel,
 	},
 	{
-		opCode: 0x302,
+		opCode: NPS_MESSAGE_IDS.SEND_RIFF_LIST,
 		name: "NPS_SEND_RIFF_LIST",
-		handler: handleSendRiffList
+		handler: handleSendRiffList,
 	},
 	{
-		opCode: 0x309,
+		opCode: NPS_MESSAGE_IDS.SEND_GAME_SERVERS_LIST,
 		name: "NPS_SEND_GAME_SERVERS_LIST",
-		handler: handleSendGameServersList
-	}
+		handler: handleSendGameServersList,
+	},
 ];

--- a/packages/lobby/src/handlers/registry.ts
+++ b/packages/lobby/src/handlers/registry.ts
@@ -22,7 +22,7 @@
  * processing a specific message type.
  */
 
-import { MessageHandlerRegistry } from 'rusty-motors-shared';
+import { MessageHandlerRegistry, NPS_MESSAGE_IDS } from 'rusty-motors-shared';
 import type { BytableMessage, BytableBuffer } from '@rustymotors/binary';
 import type { ServerLogger } from 'rusty-motors-shared';
 
@@ -60,37 +60,37 @@ export function createLobbyHandlerRegistry(): MessageHandlerRegistry<
 > {
     const registry = new MessageHandlerRegistry<LobbyHandlerArgs, LobbyHandlerResult>('lobby');
 
-    // User login request (0x100)
+    // User login request
     registry.register({
-        opCode: 0x100,
+        opCode: NPS_MESSAGE_IDS.USER_LOGIN,
         name: 'User login',
         handler: _npsRequestGameConnectServer,
     });
 
-    // Open communication channel (0x106)
+    // Open communication channel
     registry.register({
-        opCode: 0x106,
+        opCode: NPS_MESSAGE_IDS.OPEN_COMM_CHANNEL,
         name: 'PT_OPEN_COMM_CHANNEL',
         handler: handleOpenCommChannel,
     });
 
-    // UDP status (0x125)
+    // UDP status
     registry.register({
-        opCode: 0x125,
+        opCode: NPS_MESSAGE_IDS.UDP_STATUS,
         name: 'PT_UDP_STATUS',
         handler: handleUdpStatus,
     });
 
-    // Encrypted command (0x1101)
+    // Encrypted command
     registry.register({
-        opCode: 0x1101,
+        opCode: NPS_MESSAGE_IDS.ENCRYPTED_COMMAND,
         name: 'Encrypted command',
         handler: handleEncryptedNPSCommand,
     });
 
-    // Tracking ping (0x217)
+    // Tracking ping
     registry.register({
-        opCode: 0x217,
+        opCode: NPS_MESSAGE_IDS.TRACKING_PING,
         name: 'Tracking ping',
         handler: handleTrackingPing,
     });

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -86,6 +86,9 @@ export { getServerLogger } from './getServerLogger.js';
 export { NoResultsError } from './src/errors/NoResultError.js';
 export * from './src/types.js';
 
+// Message ID constants
+export * from './src/constants/index.js';
+
 // Handler utilities (Clean Code & SOLID patterns)
 export type {
     HandlerContext,

--- a/packages/shared/src/constants/AuthMessageIds.ts
+++ b/packages/shared/src/constants/AuthMessageIds.ts
@@ -1,0 +1,55 @@
+/**
+ * Authentication Message IDs
+ *
+ * These message IDs are used by the authentication system which handles
+ * login (port 8226) and persona management (port 8228).
+ *
+ * @module constants/AuthMessageIds
+ */
+
+export const AUTH_MESSAGE_IDS = {
+	// ============================================
+	// Login messages (port 8226)
+	// ============================================
+
+	/** User login request */
+	USER_LOGIN: 0x501, // 1281
+
+	// ============================================
+	// Persona messages (port 8228)
+	// ============================================
+
+	/** Game login / select persona */
+	GAME_LOGIN: 0x503, // 1283
+
+	/** Get first buddy */
+	GET_FIRST_BUDDY: 0x50b, // 1291
+
+	/** Game logout */
+	GAME_LOGOUT: 0x50f, // 1295
+
+	/** Get persona info */
+	GET_PERSONA_INFO: 0x519, // 1305
+
+	/** Get persona maps */
+	GET_PERSONA_MAPS: 0x532, // 1330
+
+	/** Validate persona name */
+	VALIDATE_PERSONA_NAME: 0x533, // 1331
+
+	// ============================================
+	// Response messages
+	// ============================================
+
+	/** Buddy info response */
+	BUDDY_INFO: 0x614, // 1556
+
+	/** Buddy list response */
+	BUDDY_LIST: 0x608, // 1544
+} as const;
+
+/**
+ * Type representing any valid auth message ID
+ */
+export type AuthMessageId =
+	(typeof AUTH_MESSAGE_IDS)[keyof typeof AUTH_MESSAGE_IDS];

--- a/packages/shared/src/constants/MCOTSMessageIds.ts
+++ b/packages/shared/src/constants/MCOTSMessageIds.ts
@@ -1,0 +1,28 @@
+/**
+ * MCOTS Protocol Message IDs (Little Endian)
+ *
+ * These message IDs are used by the MCOTS (Motor City Online Transaction System)
+ * which handles transaction communications on port 43300.
+ *
+ * Note: This file contains a minimal set of IDs. Additional IDs should be
+ * added as they are discovered and documented.
+ *
+ * @module constants/MCOTSMessageIds
+ */
+
+export const MCOTS_MESSAGE_IDS = {
+	// ============================================
+	// Transaction messages (port 43300)
+	// ============================================
+
+	/** Player info request/response */
+	PLAYER_INFO: 122,
+
+	// Additional MCOTS message IDs to be added as discovered
+} as const;
+
+/**
+ * Type representing any valid MCOTS message ID
+ */
+export type MCOTSMessageId =
+	(typeof MCOTS_MESSAGE_IDS)[keyof typeof MCOTS_MESSAGE_IDS];

--- a/packages/shared/src/constants/NPSMessageIds.ts
+++ b/packages/shared/src/constants/NPSMessageIds.ts
@@ -1,0 +1,84 @@
+/**
+ * NPS Protocol Message IDs (Big Endian)
+ *
+ * These message IDs are used by the NPS (Network Protocol System) which handles
+ * lobby, login, and persona communications on ports 7003, 8226, and 8228.
+ *
+ * @module constants/NPSMessageIds
+ */
+
+export const NPS_MESSAGE_IDS = {
+	// ============================================
+	// Lobby - Unencrypted messages (port 7003)
+	// ============================================
+
+	/** User login request */
+	USER_LOGIN: 0x100, // 256
+
+	/** Open communication channel */
+	OPEN_COMM_CHANNEL: 0x106, // 262
+
+	/** UDP status update */
+	UDP_STATUS: 0x125, // 293
+
+	/** Tracking/keepalive ping */
+	TRACKING_PING: 0x217, // 535
+
+	/** Encrypted command wrapper */
+	ENCRYPTED_COMMAND: 0x1101, // 4353
+
+	// ============================================
+	// Lobby - Inside encrypted wrapper (0x1101)
+	// ============================================
+
+	/** Get list of users in channel */
+	GET_USER_LIST: 0x101, // 257
+
+	/** Set current user's data */
+	SET_MY_USER_DATA: 0x103, // 259
+
+	/** Close communication channel */
+	CLOSE_COMM_CHANNEL: 0x105, // 261
+
+	/** Start a game server */
+	START_GAME_SERVER: 0x10a, // 266
+
+	/** Get server information */
+	GET_SERVER_INFO: 0x10c, // 268
+
+	/** Set communication channel flags */
+	SET_COMM_FLAGS: 0x10d, // 269
+
+	/** Get ready list */
+	GET_READY_LIST: 0x10e, // 270
+
+	/** Get mini user list */
+	GET_MINI_USER_LIST: 0x128, // 296
+
+	/** Send riff list */
+	SEND_RIFF_LIST: 0x302, // 770
+
+	/** Send game servers list */
+	SEND_GAME_SERVERS_LIST: 0x309, // 777
+
+	/** Send mini riff list */
+	SEND_MINI_RIFF_LIST: 0x30c, // 780
+
+	// ============================================
+	// Response messages
+	// ============================================
+
+	/** Channel granted response */
+	CHANNEL_GRANTED: 0x214, // 532
+
+	/** User joined channel notification */
+	USER_JOINED_CHANNEL: 0x20c, // 524
+
+	/** OK to login response */
+	OK_TO_LOGIN: 0x230, // 560
+} as const;
+
+/**
+ * Type representing any valid NPS message ID
+ */
+export type NPSMessageId = (typeof NPS_MESSAGE_IDS)[keyof typeof NPS_MESSAGE_IDS];

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Message ID Constants
+ *
+ * Centralized constants for all protocol message IDs used in the MCOS server.
+ *
+ * @module constants
+ */
+
+export * from "./NPSMessageIds.js";
+export * from "./AuthMessageIds.js";
+export * from "./MCOTSMessageIds.js";


### PR DESCRIPTION
## Summary

- Create `packages/shared/src/constants/` with NPS, Auth, and MCOTS message ID constants
- Update lobby and authentication handler registries to use named constants instead of magic numbers
- Update `handleOpenCommChannel.ts` to use constants for response message IDs

## Motivation

Message IDs were previously:
- Hardcoded in handler registries (`opCode: 0x100`)
- Hardcoded in message classes (`id = 0x614`)
- Scattered across packages with no central reference

This change provides:
- Single source of truth for all protocol message IDs
- Better discoverability of supported messages
- Foundation for future conflict detection and typed packets
- Improved code readability (named constants vs magic numbers)

## Test plan

- [x] All 433 unit tests pass
- [x] No hardcoded `opCode: 0x` values remain in registries
- [ ] Manual verification: Start server and verify handlers register correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a single source of truth for protocol message IDs and replaces magic numbers across handlers for clarity and consistency.
> 
> - Adds `packages/shared/src/constants/` with `NPS_MESSAGE_IDS`, `AUTH_MESSAGE_IDS`, and `MCOTS_MESSAGE_IDS`, and re-exports via `shared/index.ts`
> - Updates authentication and lobby handler registries to use `NPS_MESSAGE_IDS`/`AUTH_MESSAGE_IDS` instead of hardcoded `opCode` values
> - Switches `handleOpenCommChannel` to use `NPS_MESSAGE_IDS.USER_JOINED_CHANNEL` and `NPS_MESSAGE_IDS.CHANNEL_GRANTED` for response messages
> - Normalizes `npsCommandHandlers` to named constants (including `UDP_STATUS` and `GET_MINI_USER_LIST`) and consistent trailing commas/ordering
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6ef5775279845f11a3f97cde977a438deb2391f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->