### PR TITLE
Fix peer connection reset causing server crashes

### DIFF
--- a/packages/gateway/src/npsPortRouter.ts
+++ b/packages/gateway/src/npsPortRouter.ts
@@ -63,7 +63,8 @@ export async function npsPortRouter({
                 );
             } catch (err) {
                 log.error(`Error receiving item: ${err}`);
-                throw err;
+                // Do not re-throw - log and exit queue to prevent unhandled rejection crashes
+                receiveQueue.exit();
             }
         },
     );
@@ -93,7 +94,8 @@ export async function npsPortRouter({
                 }
             } catch (err) {
                 log.error(`Error sending item: ${err}`);
-                throw err;
+                // Do not re-throw - log and exit queue to prevent unhandled rejection crashes
+                sendQueue.exit();
             }
         },
     );

--- a/packages/gateway/src/socketErrorHandler.ts
+++ b/packages/gateway/src/socketErrorHandler.ts
@@ -1,14 +1,13 @@
 import { getServerLogger, type ServerLogger } from "rusty-motors-shared";
 
 /**
- * Handles socket errors by logging specific error codes or throwing an error.
+ * Handles socket errors by logging them.
+ * Never throws - all errors are logged to prevent uncaught exceptions from crashing the server.
  *
  * @param {Object} params - The parameters for the socket error handler.
  * @param {string} params.connectionId - The ID of the connection where the error occurred.
  * @param {NodeJS.ErrnoException} params.error - The error object containing details of the socket error.
  * @param {ServerLogger} [params.log] - Optional logger instance for logging error details. Defaults to a server logger named "socketErrorHandler".
- *
- * @throws {Error} Throws an error if the socket error code is not handled.
  */
 export function socketErrorHandler({
 	connectionId,
@@ -19,10 +18,14 @@ export function socketErrorHandler({
 	error: NodeJS.ErrnoException;
 	log?: ServerLogger;
 }) {
-	// Handle socket errors
-	if (error.code == "ECONNRESET") {
-		log.debug(`Connection ${connectionId} reset`);
+	// Handle socket errors - all errors are logged, never thrown
+	if (error.code === "ECONNRESET") {
+		log.debug(`Connection ${connectionId} reset by peer`);
 		return;
 	}
-	throw Error(`Socket error: ${error.message} on connection ${connectionId}`);
+	// Log other socket errors without throwing - throwing from event handlers crashes the process
+	log.error(`Socket error on connection ${connectionId}: ${error.message}`, {
+		code: error.code,
+		errno: error.errno,
+	});
 }

--- a/packages/gateway/test/socketErrorHandler.test.ts
+++ b/packages/gateway/test/socketErrorHandler.test.ts
@@ -13,11 +13,11 @@ describe("socketErrorHandler", () => {
 		socketErrorHandler({ connectionId, error, log: mockLogger });
 
 		expect(mockLogger.debug).toHaveBeenCalledWith(
-			`Connection ${connectionId} reset`,
+			`Connection ${connectionId} reset by peer`,
 		);
 	});
 
-	it("should throw an error when error code is not handled", () => {
+	it("should log an error when error code is not handled", () => {
 		const connectionId = "12345";
 		const error = {
 			code: "EUNKNOWN",
@@ -25,10 +25,17 @@ describe("socketErrorHandler", () => {
 		} as NodeJS.ErrnoException;
 		const mockLogger = {
 			debug: vi.fn(),
+			error: vi.fn(),
 		} as unknown as ServerLogger;
 
-		expect(() =>
-			socketErrorHandler({ connectionId, error, log: mockLogger }),
-		).toThrow(`Socket error: ${error.message} on connection ${connectionId}`);
+		socketErrorHandler({ connectionId, error, log: mockLogger });
+
+		expect(mockLogger.error).toHaveBeenCalledWith(
+			`Socket error on connection ${connectionId}: ${error.message}`,
+			expect.objectContaining({
+				code: error.code,
+				errno: error.errno,
+			}),
+		);
 	});
 });


### PR DESCRIPTION
Prevent uncaught exceptions and unhandled promise rejections from crashing the server:

- socketErrorHandler: Stop throwing errors from socket event handlers, which would cause uncaught exceptions and crash the process. Now all errors are logged instead.
- npsPortRouter: Don't re-throw errors in MessageQueue callbacks, which would cause unhandled promise rejections. Exit queue gracefully on error.
- Update socketErrorHandler tests to match new logging-only behavior

This addresses issues where ECONNRESET and other socket errors would crash the entire server process instead of being handled gracefully.

All tests pass:
- 167 gateway tests
- 433 unit tests
- 456 session tests

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents server crashes by handling socket and queue errors gracefully instead of throwing.
> 
> - `npsPortRouter`: In `MessageQueue` `receive`/`send` handlers, stop re-throwing on error; log and call `queue.exit()` to avoid unhandled rejections
> - `socketErrorHandler`: Never throws; logs `ECONNRESET` at debug and logs other errors with metadata
> - Tests updated to assert logging behavior instead of thrown errors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08cc834c43649b742ddc89d8225d0f52b62212f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->