### PR TITLE
Move nginx off :443 for pyswitch TLS relay router

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
         build:
             context: services/sslProxy
         ports:
-            - "443:443"
+            - "127.0.0.1:9443:443"
             - "80:80"
         restart: always
         extra_hosts:


### PR DESCRIPTION
## Summary
Same change as #2833 (closed — that branch was based off `udp-game-room`, which has diverged too far from `main` for a clean merge), rebuilt directly on `main` against its current `docker-compose.yml` location/structure.

- nginx's public port mapping changes from `443:443` to `127.0.0.1:9443:443` — loopback-only, no other config changes.
- Frees `:443` for `pyswitch` (rustymotors/pyswitch#4), which now classifies incoming connections and routes legacy SSLv2 (old game clients, needing this nginx's `HIGH:MEDIUM`/SSLv3 cert) vs. modern TLS (routed to Caddy, serving other domains) on the same public port.
- Port `80` is untouched.

## Test plan
- [x] Deployed live: nginx container recreated with the new mapping, confirmed still serving its existing cert correctly on `127.0.0.1:9443`
- [x] Confirmed `:443` free and now bound by pyswitch
- [x] Confirmed a legacy-shaped SSLv2 byte stream through pyswitch correctly reaches this nginx on `9443` (pyswitch's own log)